### PR TITLE
Fix dark mode toggle on movies and venues pages

### DIFF
--- a/bmsv3_frontend/movies.js
+++ b/bmsv3_frontend/movies.js
@@ -80,35 +80,38 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     fetchMovies();
-        const themeSwitch = document.getElementById('theme-checkbox');
     const body = document.body;
+    const themeToggle = document.getElementById('sidebar-theme-toggle'); // Correct ID for the sidebar toggle
 
+    // --- Dark Mode Logic (Complete and Correct) ---
     const applyTheme = (theme) => {
         if (theme === 'night') {
             body.classList.remove('day-mode');
             body.classList.add('night-mode');
-            themeSwitch.checked = true;
         } else {
             body.classList.remove('night-mode');
             body.classList.add('day-mode');
-            themeSwitch.checked = false;
         }
     };
 
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme) {
         applyTheme(savedTheme);
+    } else {
+        applyTheme('day'); // Default to day mode
     }
 
-    themeSwitch.addEventListener('change', () => {
-        if (themeSwitch.checked) {
-            localStorage.setItem('theme', 'night');
-            applyTheme('night');
-        } else {
-            localStorage.setItem('theme', 'day');
-            applyTheme('day');
-        }
-    });
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            if (body.classList.contains('day-mode')) {
+                localStorage.setItem('theme', 'night');
+                applyTheme('night');
+            } else {
+                localStorage.setItem('theme', 'day');
+                applyTheme('day');
+            }
+        });
+    }
 
     // --- Logout Prompt Logic ---
     const logoutButton = document.getElementById('logout-button');

--- a/bmsv3_frontend/venues.js
+++ b/bmsv3_frontend/venues.js
@@ -24,37 +24,38 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    // === THIS IS THE CORRECTED DARK MODE LOGIC ===
-    const themeSwitch = document.getElementById('theme-checkbox');
     const body = document.body;
+    const themeToggle = document.getElementById('sidebar-theme-toggle'); // Correct ID for the sidebar toggle
 
+    // --- Dark Mode Logic (Complete and Correct) ---
     const applyTheme = (theme) => {
         if (theme === 'night') {
             body.classList.remove('day-mode');
             body.classList.add('night-mode');
-            themeSwitch.checked = true;
         } else {
             body.classList.remove('night-mode');
             body.classList.add('day-mode');
-            themeSwitch.checked = false;
         }
     };
 
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme) {
         applyTheme(savedTheme);
+    } else {
+        applyTheme('day'); // Default to day mode
     }
 
-    themeSwitch.addEventListener('change', () => {
-        if (themeSwitch.checked) {
-            localStorage.setItem('theme', 'night');
-            applyTheme('night');
-        } else {
-            localStorage.setItem('theme', 'day');
-            applyTheme('day');
-        }
-    });
-    // === END OF CORRECTED LOGIC ===
+    if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+            if (body.classList.contains('day-mode')) {
+                localStorage.setItem('theme', 'night');
+                applyTheme('night');
+            } else {
+                localStorage.setItem('theme', 'day');
+                applyTheme('day');
+            }
+        });
+    }
 
     // --- Logout Prompt Logic ---
     const logoutButton = document.getElementById('logout-button');


### PR DESCRIPTION
The dark mode toggle on the movies and venues pages was not functional. This was because the JavaScript code was looking for a non-existent element with the ID `theme-checkbox` and was using logic for a checkbox element.

This commit replaces the incorrect JavaScript logic in `movies.js` and `venues.js` with the correct logic from `bookings.js`, which has a working dark mode toggle. The new logic correctly targets the element with the ID `sidebar-theme-toggle`, uses a `click` event listener, and toggles the theme by manipulating the class list of the `body` element.